### PR TITLE
Add stagein step when no inputs are needed to be downloaded

### DIFF
--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -117,6 +117,10 @@ class Blender:
         if type(where) is not dict:
             raise Exception("on_stage -> in must be a dict")
 
+        # Add dummy input from added stagein to ensure the order of steps is preserved
+        if "dummy_input" in directories_out:
+            where["dummy_input"] = directories_out["dummy_input"]
+
         for it in inp:
             if type(it) is str:
                 if it in directories_out:
@@ -402,8 +406,8 @@ class Blender:
             # Add dummy outputs to ensure step order
             command_out = copy.deepcopy(self.rulez.get("/cwl/outputBindingResult/command/Directory"))
 
-            command_id = "%s_out" % it.id
-            nodes_out[it.id] = "%s/%s_out" % (start_node_name, it.id)
+            command_id = "%s_out" % "dummy_input"
+            nodes_out[it.id] = "%s/%s_out" % (start_node_name, "dummy_input")
             if type(the_command_outputs) is list:
                 command_out["id"] = command_id
                 the_command_outputs.append(command_out)
@@ -415,20 +419,6 @@ class Blender:
 
             cursor = cursor + 1
             start_node_name = "%s_%d" % (start_node_name, cursor)
-
-            # # ON_STAGE!
-            # on_stage_node = self.rulez.get("/onstage/on_stage/connection_node")
-            # if on_stage_node == "":
-            #     on_stage_node = "on_stage"
-
-            # self.__prepare_step_run(steps, on_stage_node)
-
-            # steps[on_stage_node]["run"] = f"#{self.user_wf.get_id()}"
-
-            # if steps[on_stage_node]["run"] == "":
-            #     raise Exception('Workflow without "id"')
-
-            # self.__create_on_stage_inputs(steps[on_stage_node]["in"], nodes_out)
 
         else: 
             # Case where stagein used to load data for workflow
@@ -511,19 +501,19 @@ class Blender:
                 cursor = cursor + 1
                 start_node_name = "%s_%d" % (start_node_name, cursor)
 
-            # ON_STAGE!
-            on_stage_node = self.rulez.get("/onstage/on_stage/connection_node")
-            if on_stage_node == "":
-                on_stage_node = "on_stage"
+        # ON_STAGE!
+        on_stage_node = self.rulez.get("/onstage/on_stage/connection_node")
+        if on_stage_node == "":
+            on_stage_node = "on_stage"
 
-            self.__prepare_step_run(steps, on_stage_node)
+        self.__prepare_step_run(steps, on_stage_node)
 
-            steps[on_stage_node]["run"] = f"#{self.user_wf.get_id()}"
+        steps[on_stage_node]["run"] = f"#{self.user_wf.get_id()}"
 
-            if steps[on_stage_node]["run"] == "":
-                raise Exception('Workflow without "id"')
+        if steps[on_stage_node]["run"] == "":
+            raise Exception('Workflow without "id"')
 
-            self.__create_on_stage_inputs(steps[on_stage_node]["in"], nodes_out)
+        self.__create_on_stage_inputs(steps[on_stage_node]["in"], nodes_out)
 
         # stage out
         connection_node_node_stage_out = self.rulez.get("/onstage/stage_out/connection_node")

--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -646,7 +646,4 @@ class Blender:
 
         self.start = self.__add_stage_in_graph_cwl()
 
-        print("Self start")
-        print(self.start)
-
         return self.start

--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -407,7 +407,7 @@ class Blender:
             command_out = copy.deepcopy(self.rulez.get("/cwl/outputBindingResult/command/Directory"))
 
             command_id = "%s_out" % "dummy_input"
-            nodes_out[it.id] = "%s/%s_out" % (start_node_name, "dummy_input")
+            nodes_out["dummy_input"] = "%s/%s_out" % (start_node_name, "dummy_input")
             if type(the_command_outputs) is list:
                 command_out["id"] = command_id
                 the_command_outputs.append(command_out)

--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -416,19 +416,19 @@ class Blender:
             cursor = cursor + 1
             start_node_name = "%s_%d" % (start_node_name, cursor)
 
-            # ON_STAGE!
-            on_stage_node = self.rulez.get("/onstage/on_stage/connection_node")
-            if on_stage_node == "":
-                on_stage_node = "on_stage"
+            # # ON_STAGE!
+            # on_stage_node = self.rulez.get("/onstage/on_stage/connection_node")
+            # if on_stage_node == "":
+            #     on_stage_node = "on_stage"
 
-            self.__prepare_step_run(steps, on_stage_node)
+            # self.__prepare_step_run(steps, on_stage_node)
 
-            steps[on_stage_node]["run"] = f"#{self.user_wf.get_id()}"
+            # steps[on_stage_node]["run"] = f"#{self.user_wf.get_id()}"
 
-            if steps[on_stage_node]["run"] == "":
-                raise Exception('Workflow without "id"')
+            # if steps[on_stage_node]["run"] == "":
+            #     raise Exception('Workflow without "id"')
 
-            self.__create_on_stage_inputs(steps[on_stage_node]["in"], nodes_out)
+            # self.__create_on_stage_inputs(steps[on_stage_node]["in"], nodes_out)
 
         else: 
             # Case where stagein used to load data for workflow

--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -383,16 +383,13 @@ class Blender:
 
         # Case where stage in only used for aws credentials
         if not self.inputs:
-            logger.info("Adding basic stage in step") 
+            logger.info("Adding stage-in step for credentials only") 
             self.__prepare_step_run(steps, start_node_name, in_main_template)
-            logger.info(f"start node name is {start_node_name}")
-            logger.info(steps[start_node_name])
             the_command = copy.deepcopy(self.main_stage_in)  # self.main_stage_in.copy()
             the_command_inputs = the_command["inputs"]
             the_command_outputs = the_command["outputs"]
-            logger.info("The command")
-            logger.info(the_command)
 
+            # Add default inputs
             if type(the_command_inputs) is list:
                 for i in the_command_inputs:
                     self.__add_to_in(steps[start_node_name]["in"], i["id"])

--- a/src/cwl_wrapper/blender.py
+++ b/src/cwl_wrapper/blender.py
@@ -380,6 +380,32 @@ class Blender:
             in_main_template = copy.deepcopy(steps[connection_node_node_stage_in])
 
         # stage in
+
+        # Case where stage in only used for aws credentials
+        if not self.inputs:
+            logger.info("Adding basic stage in step") 
+            self.__prepare_step_run(steps, start_node_name, in_main_template)
+            logger.info(f"start node name is {start_node_name}")
+            logger.info(steps[start_node_name])
+            the_command = copy.deepcopy(self.main_stage_in)  # self.main_stage_in.copy()
+            the_command_inputs = the_command["inputs"]
+            the_command_outputs = the_command["outputs"]
+            logger.info("The command")
+            logger.info(the_command)
+
+            if type(the_command_inputs) is list:
+                for i in the_command_inputs:
+                    self.__add_to_in(steps[start_node_name]["in"], i["id"])
+            elif type(the_command_inputs) is dict:
+                for i in the_command_inputs:
+                    self.__add_to_in(steps[start_node_name]["in"], i)
+
+            steps[start_node_name]["run"] = the_command
+
+            cursor = cursor + 1
+            start_node_name = "%s_%d" % (start_node_name, cursor)
+
+        # Case where stagein used to load data for workflow
         for it in self.inputs:
             # print(f'Nodo: {start_node_name}  ')
             self.__prepare_step_run(steps, start_node_name, in_main_template)


### PR DESCRIPTION
## Ensure Stagein always run for workflows
- The stagein step has now been extended to also generate AWS Credentials to allow S3 access
- This update ensures the stagein is always run for a workflow, even if there is no additional data to stagein for the workflow execution
- This adds a generic stagein step to the generated workflow, even when no Directory inputs were provided in the user workflow
- This stegin step has no additional inputs, only those required to generate AWS credentials
- If the stagein is to be run on Directory inputs, the workflow runs as normal